### PR TITLE
Apply final Foundation policy decisions — jmerrill.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# jmerrill.foundation — Site Deployment Guide
+# jmerrill.org — Site Deployment Guide
 
-**Project:** J Merrill Foundation Inc. Website  
-**Domain:** jmerrill.foundation  
-**Stack:** Next.js 14 App Router · TypeScript · Tailwind CSS  
-**Hosting:** Azure Static Web Apps (JM1 Foundation Azure credit)  
-**Repository:** github.com/jmerrillorg/jmerrill-foundation  
+**Project:** J Merrill Foundation Inc. Website
+**Canonical Domain:** www.jmerrill.org
+**Secondary Domain:** jmerrill.foundation may remain redirected or secondary
+**Stack:** Next.js 14 App Router · TypeScript · Tailwind CSS
+**Hosting:** Azure Static Web Apps (JM1 Foundation Azure credit)
+**Repository:** github.com/jmerrillorg/jmerrill-foundation
 
 ---
 
@@ -73,9 +74,9 @@ Azure will auto-generate the GitHub Actions workflow token and add it to the rep
 ### Step 5 — Custom Domain
 
 1. In Azure Static Web Apps → Custom domains → Add
-2. Enter: `www.jmerrill.foundation`
+2. Enter: `www.jmerrill.org`
 3. Add the CNAME record to DNS at your domain registrar pointing to the Azure-provided hostname
-4. Also add: `jmerrill.foundation` (apex) → use Azure's alias record or redirect
+4. Keep `jmerrill.foundation` as a secondary redirected domain if needed
 
 ### Step 6 — Microsoft Forms Embed
 
@@ -128,7 +129,7 @@ When Stripe is ready:
 | /volunteer | Get involved | 6 opportunity cards + embedded MS Forms intake |
 | /donate | Giving | Stripe placeholder, where it goes breakdown, 4 named giving tiers |
 | /story-hour | Digital library | How it works, QR bridge, copyright tiers, reader CTA |
-| /classroom-author | Signature program | Chillicothe proof, 5-step process, youth pipeline, school partnership CTA |
+| /classroom-author | Signature program | Chillicothe proof, 5-step process, planned youth author opportunities, school partnership CTA |
 | /our-libraries | Reading Stations | Parsons Ave station details, charter info, expansion plan |
 
 ---

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -10,7 +10,7 @@ const tiers = [
   { name: 'Literacy Circle', amount: '$500/yr', description: 'Helps support books, literacy access, and community program operations. Recognition may be offered according to Foundation policy.', color: 'var(--text-muted)', bg: 'var(--surface)' },
   { name: 'Story Champion', amount: '$2,500/yr', description: 'Helps support Story Hour development, reader coordination, and access to read-aloud experiences for children and families.', color: 'var(--primary)', bg: 'rgba(147, 50, 158, 0.05)', featured: true },
   { name: 'Legacy Partner', amount: '$10,000/yr', description: 'Helps support larger program needs, school partnerships, reading access, and community literacy work over time.', color: '#1A5276', bg: '#D6EAF8' },
-  { name: 'Endowment Seat', amount: '$50,000+', description: 'Helps support long-term Foundation capacity and program sustainability. Legacy giving conversations may be coordinated separately upon request.', color: '#7B4F00', bg: '#FFF3CD' },
+  { name: 'Sustaining Gift', amount: '$50,000+', description: 'Helps support long-term Foundation capacity and program sustainability. Legacy giving conversations may be coordinated separately upon request.', color: '#7B4F00', bg: '#FFF3CD' },
 ]
 
 export default function DonatePage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    url: 'https://jmerrill.org',
+    url: 'https://www.jmerrill.org',
     siteName: 'J Merrill Foundation Inc.',
     title: 'J Merrill Foundation Inc. — Literacy. Community. Transformation.',
     description: 'Advancing literacy, dignity, authorship, and community access across Columbus, Ohio.',


### PR DESCRIPTION
## Summary

Follow-up to merged PR #3 for the final Jackie policy decisions supplied after Phase 2 review.

This PR applies the remaining final-alignment items that landed after PR #3 was merged:

- Sets Open Graph canonical URL to `https://www.jmerrill.org`.
- Updates README domain references so `www.jmerrill.org` is canonical and `jmerrill.foundation` is secondary/redirectable.
- Replaces the public donation tier label `Endowment Seat` with `Sustaining Gift` while preserving the amount and softened support language.
- Updates README Classroom Author summary from youth pipeline language to planned youth author opportunities.

## Files changed

- `README.md`
- `src/app/layout.tsx`
- `src/app/donate/page.tsx`

## Explicit non-changes

No forms, payment links, integrations, API routes, data models, authentication, analytics, route structure, navigation structure, brand colors, visual identity, or layout redesigns were changed.

## Validation results

- `git diff --check origin/main...HEAD`: passed.
- `pnpm install --frozen-lockfile`, `pnpm lint`, and `pnpm build` were not rerun because `pnpm` is not installed in this Codex desktop shell.